### PR TITLE
Add ability to define DOCDIR, leave default as previous

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ ifeq ($(strip $(ASTLIBDIR)),)
 else
 	MODULES_DIR:=$(INSTALL_PREFIX)$(ASTLIBDIR)
 endif
+ifeq ($(strip $(DOCDIR)),)
+	DOCUMENTATION_DIR:=$(INSTALL_PREFIX)/usr/share/asterisk/documentation/thirdparty
+else
+	DOCUMENTATION_DIR:=$(INSTALL_PREFIX)$(DOCDIR)
+endif
 INSTALL = install
 ASTETCDIR = $(INSTALL_PREFIX)/etc/asterisk
 SAMPLENAME = amqp.conf.sample
@@ -37,9 +42,9 @@ $(TARGET): $(OBJECTS)
 
 install: $(TARGET)
 	mkdir -p $(DESTDIR)$(MODULES_DIR)
-	mkdir -p $(DESTDIR)/usr/share/asterisk/documentation/thirdparty
+	mkdir -p $(DESTDIR)$(DOCUMENTATION_DIR)
 	install -m 644 $(TARGET) $(DESTDIR)$(MODULES_DIR)
-	install -m 644 documentation/* $(DESTDIR)/usr/share/asterisk/documentation/thirdparty
+	install -m 644 documentation/* $(DESTDIR)$(DOCUMENTATION_DIR)
 	@echo " +----------- res_amqp installed ------------+"
 	@echo " +                                           +"
 	@echo " + res_amqp has successfully been installed  +"


### PR DESCRIPTION
In Wazo the documentation directory is /usr/share/asterisk/documentation/thirdparty

In FreePBX the documentation directory is /var/lib{64}/asterisk/documentation

This PR allows setting DOCDIR to set the documentation directory. If DOCDIR is not set then it uses the Wazo default of /usr/share/asterisk/documentation/thirdparty

I've tested by running with and without DOCDIR and it works correctly in both cases.